### PR TITLE
keep groupstats dialog above qgis main window

### DIFF
--- a/groupstats.py
+++ b/groupstats.py
@@ -73,7 +73,7 @@ class GroupStats:
     def run(self):
         if self.dlg is None:
             # Create the dialog and keep reference
-            self.dlg = GroupStatsDialog()
+            self.dlg = GroupStatsDialog(self.iface.mainWindow())
 
         mapLayers = QgsProject.instance().mapLayers()        # Load layers dictionary from the project
         layerList = []


### PR DESCRIPTION
Hey 👋

just a small tweak to make it so the GroupStats dialog always stays on top of the QGIS main window if the user interacts with anything outside the dialog while it is open. Until now, the dialog would move behind the main window if the user interacted with it.

Regards